### PR TITLE
Fix issue with import of reimprovejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.3",
   "private": false,
   "description": "A library using TensorFlow.js for Deep Reinforcement Learning",
-  "main": "./dist/index.js",
+  "main": "./dist/reimprove.js",
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
If using ReImproveJS via `npm` the following will fail:

`import reimprove from 'reimprovejs';`

This is because the `package.json` points to a file in the /dist that does not exist.

Absent a change, you have to do the following:

`import reimprove from 'reimprovejs/dist/reimprove.js';`